### PR TITLE
refactor: update CI workflow to include pull request triggers for mai…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,12 @@
 name: Continuous Integration
 
 on: 
+  pull_request:
+    branches:
+      - main
+      - rc
+      - dev
+      - feature/*
   push:
     branches:
       - main


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration to enhance the triggering of the Continuous Integration (CI) pipeline.

Workflow trigger updates:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR4-R9): Added a `pull_request` trigger to the CI workflow, specifying that it should run for pull requests targeting the `main`, `rc`, `dev`, and `feature/*` branches.