### PR TITLE
refactor: enable gRPC and worker options in CD workflow; update ms-base dependency version in Helm charts

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -45,7 +45,7 @@ jobs:
       project-name: CodeDesignPlus.Net.Microservice
       microservice-name: ms-archetype
       enable-rest: true
-      enable-grpc: false
-      enable-worker: false
+      enable-grpc: true
+      enable-worker: true
       environment: ${{ github.event.inputs.environment }}
     secrets: inherit

--- a/charts/ms-archetype-grpc/Chart.yaml
+++ b/charts/ms-archetype-grpc/Chart.yaml
@@ -6,5 +6,5 @@ version: 0.0.1
 appVersion: "0.0.1"
 dependencies:
   - name: ms-base
-    version: 0.0.1
+    version: 0.0.6
     repository: "https://www.codedesignplus.com/helm-charts/"

--- a/charts/ms-archetype-rest/Chart.yaml
+++ b/charts/ms-archetype-rest/Chart.yaml
@@ -6,5 +6,5 @@ version: 0.0.1
 appVersion: "0.0.1"
 dependencies:
   - name: ms-base
-    version: 0.0.1
+    version: 0.0.6
     repository: "https://www.codedesignplus.com/helm-charts/"

--- a/charts/ms-archetype-worker/Chart.yaml
+++ b/charts/ms-archetype-worker/Chart.yaml
@@ -6,5 +6,5 @@ version: 0.0.1
 appVersion: "0.0.1"
 dependencies:
   - name: ms-base
-    version: 0.0.1
+    version: 0.0.6
     repository: "https://www.codedesignplus.com/helm-charts/"

--- a/src/entrypoints/CodeDesignPlus.Net.Microservice.Rest/Program.cs
+++ b/src/entrypoints/CodeDesignPlus.Net.Microservice.Rest/Program.cs
@@ -9,7 +9,7 @@ using CodeDesignPlus.Net.Vault.Extensions;
 using NodaTime.Serialization.SystemTextJson;
 
 
-    var builder = WebApplication.CreateSlimBuilder(args);
+var builder = WebApplication.CreateSlimBuilder(args);
 
 Serilog.Debugging.SelfLog.Enable(Console.Error);
 


### PR DESCRIPTION
This pull request introduces updates to the deployment configuration and Helm charts for the `ms-archetype` microservice. The most significant changes include enabling gRPC and worker services in the CI/CD workflow and updating the `ms-base` dependency version across all related Helm charts.

### CI/CD Workflow Updates:
* [`.github/workflows/cd.yaml`](diffhunk://#diff-7820634de9167dbbf6a1ab9e9c02aab3b8b0ca512494aca230074fd13f630adeL48-R49): Enabled gRPC (`enable-grpc: true`) and worker (`enable-worker: true`) services in the CI/CD pipeline configuration. This ensures these components are included in the deployment process.

### Helm Chart Dependency Updates:
* [`charts/ms-archetype-grpc/Chart.yaml`](diffhunk://#diff-7ee971debf98d3b57e218c9ae85a284d050f9c15c2917910b7c34e3aef45c8c3L9-R9): Updated the `ms-base` dependency version from `0.0.1` to `0.0.6` to incorporate the latest features and fixes.
* [`charts/ms-archetype-rest/Chart.yaml`](diffhunk://#diff-a67fd362562daea76fb9aa6c8016a020d87d465b10beb024e53d39082686c7f8L9-R9): Updated the `ms-base` dependency version from `0.0.1` to `0.0.6`.
* [`charts/ms-archetype-worker/Chart.yaml`](diffhunk://#diff-265e56b7fdae69a8c1695a1e0e8427c8cfc9ec580de5dc2a922eb1e0e1c3e4f4L9-R9): Updated the `ms-base` dependency version from `0.0.1` to `0.0.6`.