### PR TITLE
refactor: add health checks service integration in gRPC and AsyncWorker entry points

### DIFF
--- a/src/entrypoints/CodeDesignPlus.Net.Microservice.AsyncWorker/Program.cs
+++ b/src/entrypoints/CodeDesignPlus.Net.Microservice.AsyncWorker/Program.cs
@@ -1,5 +1,6 @@
 using CodeDesignPlus.Net.Logger.Extensions;
 using CodeDesignPlus.Net.Microservice.Commons.FluentValidation;
+using CodeDesignPlus.Net.Microservice.Commons.HealthChecks;
 using CodeDesignPlus.Net.Microservice.Commons.MediatR;
 using CodeDesignPlus.Net.Mongo.Extensions;
 using CodeDesignPlus.Net.RabbitMQ.Extensions;
@@ -26,11 +27,11 @@ builder.Services.AddCache(builder.Configuration);
 builder.Services.AddMapster();
 builder.Services.AddFluentValidation();
 builder.Services.AddMediatR<CodeDesignPlus.Net.Microservice.Application.Startup>();
+builder.Services.AddHealthChecksServices();
 
 var app = builder.Build();
 
-// if(app.Environment.IsStaging())
-//     app.UsePathBase("/ms-archetype");
+app.UseHealthChecks();
     
 var home = app.MapGroup("/");
 

--- a/src/entrypoints/CodeDesignPlus.Net.Microservice.gRpc/Program.cs
+++ b/src/entrypoints/CodeDesignPlus.Net.Microservice.gRpc/Program.cs
@@ -1,6 +1,7 @@
 using CodeDesignPlus.Net.Logger.Extensions;
 using CodeDesignPlus.Net.Microservice.Commons.EntryPoints.gRpc.Interceptors;
 using CodeDesignPlus.Net.Microservice.Commons.FluentValidation;
+using CodeDesignPlus.Net.Microservice.Commons.HealthChecks;
 using CodeDesignPlus.Net.Microservice.Commons.MediatR;
 using CodeDesignPlus.Net.Microservice.gRpc.Services;
 using CodeDesignPlus.Net.Mongo.Extensions;
@@ -37,11 +38,11 @@ builder.Services.AddSecurity(builder.Configuration);
 builder.Services.AddObservability(builder.Configuration, builder.Environment);
 builder.Services.AddLogger(builder.Configuration);
 builder.Services.AddCache(builder.Configuration);
+builder.Services.AddHealthChecksServices();
 
 var app = builder.Build();
 
-// if(app.Environment.IsStaging())
-//     app.UsePathBase("/ms-archetype");
+app.UseHealthChecks();
     
 app.UseAuth();
 


### PR DESCRIPTION
This pull request introduces health check functionality to two microservice entry points (`AsyncWorker` and `gRpc`) to improve service monitoring and reliability. The changes include adding health check dependencies, registering health check services, and enabling health check endpoints in the application pipeline.

### Health Check Integration:

* `src/entrypoints/CodeDesignPlus.Net.Microservice.AsyncWorker/Program.cs`:  
  - Added the `CodeDesignPlus.Net.Microservice.Commons.HealthChecks` namespace for health check functionality.  
  - Registered health check services with `builder.Services.AddHealthChecksServices()` and enabled health check endpoints with `app.UseHealthChecks()`.

* `src/entrypoints/CodeDesignPlus.Net.Microservice.gRpc/Program.cs`:  
  - Added the `CodeDesignPlus.Net.Microservice.Commons.HealthChecks` namespace for health check functionality.  
  - Registered health check services with `builder.Services.AddHealthChecksServices()` and enabled health check endpoints with `app.UseHealthChecks()`.