### PR TITLE
refactor: update package versions to 0.7.0-beta.28 across multiple projects

### DIFF
--- a/src/domain/CodeDesignPlus.Net.Microservice.Application/CodeDesignPlus.Net.Microservice.Application.csproj
+++ b/src/domain/CodeDesignPlus.Net.Microservice.Application/CodeDesignPlus.Net.Microservice.Application.csproj
@@ -5,10 +5,10 @@
 		<Nullable>enable</Nullable>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="CodeDesignPlus.Net.Generator" Version="0.7.0-beta.16" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
-		<PackageReference Include="CodeDesignPlus.Net.Redis.Abstractions" Version="0.7.0-beta.16" />
-		<PackageReference Include="CodeDesignPlus.Net.PubSub.Abstractions" Version="0.7.0-beta.16" />
-		<PackageReference Include="CodeDesignPlus.Net.Cache.Abstractions" Version="0.7.0-beta.16" />
+		<PackageReference Include="CodeDesignPlus.Net.Generator" Version="0.7.0-beta.28" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+		<PackageReference Include="CodeDesignPlus.Net.Redis.Abstractions" Version="0.7.0-beta.28" />
+		<PackageReference Include="CodeDesignPlus.Net.PubSub.Abstractions" Version="0.7.0-beta.28" />
+		<PackageReference Include="CodeDesignPlus.Net.Cache.Abstractions" Version="0.7.0-beta.28" />
 		<PackageReference Include="Mapster" Version="7.4.0" />
 		<PackageReference Include="Mapster.DependencyInjection" Version="1.0.1" />
 		<PackageReference Include="MediatR" Version="12.5.0" />

--- a/src/domain/CodeDesignPlus.Net.Microservice.Domain/CodeDesignPlus.Net.Microservice.Domain.csproj
+++ b/src/domain/CodeDesignPlus.Net.Microservice.Domain/CodeDesignPlus.Net.Microservice.Domain.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CodeDesignPlus.Net.Exceptions" Version="0.7.0-beta.16" />
-    <PackageReference Include="CodeDesignPlus.Net.Mongo" Version="0.7.0-beta.16" /> 
+    <PackageReference Include="CodeDesignPlus.Net.Exceptions" Version="0.7.0-beta.28" />
+    <PackageReference Include="CodeDesignPlus.Net.Mongo" Version="0.7.0-beta.28" /> 
   </ItemGroup>
 </Project>

--- a/src/entrypoints/CodeDesignPlus.Net.Microservice.AsyncWorker/CodeDesignPlus.Net.Microservice.AsyncWorker.csproj
+++ b/src/entrypoints/CodeDesignPlus.Net.Microservice.AsyncWorker/CodeDesignPlus.Net.Microservice.AsyncWorker.csproj
@@ -7,14 +7,14 @@
     <PublishAot>false</PublishAot>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CodeDesignPlus.Net.Microservice.Commons" Version="0.7.0-beta.16" />
-    <PackageReference Include="CodeDesignPlus.Net.Vault" Version="0.7.0-beta.16" />
-    <PackageReference Include="CodeDesignPlus.Net.Redis" Version="0.7.0-beta.16" />
-    <PackageReference Include="CodeDesignPlus.Net.RabbitMQ" Version="0.7.0-beta.16" />
-    <PackageReference Include="CodeDesignPlus.Net.Logger" Version="0.7.0-beta.16" />
-    <PackageReference Include="CodeDesignPlus.Net.Observability" Version="0.7.0-beta.16" />
-    <PackageReference Include="CodeDesignPlus.Net.Security" Version="0.7.0-beta.16" />
-    <PackageReference Include="CodeDesignPlus.Net.Redis.Cache" Version="0.7.0-beta.16" />
+    <PackageReference Include="CodeDesignPlus.Net.Microservice.Commons" Version="0.7.0-beta.28" />
+    <PackageReference Include="CodeDesignPlus.Net.Vault" Version="0.7.0-beta.28" />
+    <PackageReference Include="CodeDesignPlus.Net.Redis" Version="0.7.0-beta.28" />
+    <PackageReference Include="CodeDesignPlus.Net.RabbitMQ" Version="0.7.0-beta.28" />
+    <PackageReference Include="CodeDesignPlus.Net.Logger" Version="0.7.0-beta.28" />
+    <PackageReference Include="CodeDesignPlus.Net.Observability" Version="0.7.0-beta.28" />
+    <PackageReference Include="CodeDesignPlus.Net.Security" Version="0.7.0-beta.28" />
+    <PackageReference Include="CodeDesignPlus.Net.Redis.Cache" Version="0.7.0-beta.28" />
   </ItemGroup>
   <ItemGroup>
     <SonarQubeSetting Include="sonar.coverage.exclusions">

--- a/src/entrypoints/CodeDesignPlus.Net.Microservice.Rest/CodeDesignPlus.Net.Microservice.Rest.csproj
+++ b/src/entrypoints/CodeDesignPlus.Net.Microservice.Rest/CodeDesignPlus.Net.Microservice.Rest.csproj
@@ -11,17 +11,17 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NodaTime.Serialization.SystemTextJson" Version="1.3.0" />
-    <PackageReference Include="CodeDesignPlus.Net.Microservice.Commons" Version="0.7.0-beta.16" />
-    <PackageReference Include="CodeDesignPlus.Net.Vault" Version="0.7.0-beta.16" />
+    <PackageReference Include="CodeDesignPlus.Net.Microservice.Commons" Version="0.7.0-beta.28" />
+    <PackageReference Include="CodeDesignPlus.Net.Vault" Version="0.7.0-beta.28" />
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="8.1.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="8.1.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="8.1.1" />
-    <PackageReference Include="CodeDesignPlus.Net.Logger" Version="0.7.0-beta.16" />
-    <PackageReference Include="CodeDesignPlus.Net.Redis" Version="0.7.0-beta.16" />
-    <PackageReference Include="CodeDesignPlus.Net.Security" Version="0.7.0-beta.16" />
-    <PackageReference Include="CodeDesignPlus.Net.Observability" Version="0.7.0-beta.16" />
-    <PackageReference Include="CodeDesignPlus.Net.RabbitMQ" Version="0.7.0-beta.16" />
-    <PackageReference Include="CodeDesignPlus.Net.Redis.Cache" Version="0.7.0-beta.16" />
+    <PackageReference Include="CodeDesignPlus.Net.Logger" Version="0.7.0-beta.28" />
+    <PackageReference Include="CodeDesignPlus.Net.Redis" Version="0.7.0-beta.28" />
+    <PackageReference Include="CodeDesignPlus.Net.Security" Version="0.7.0-beta.28" />
+    <PackageReference Include="CodeDesignPlus.Net.Observability" Version="0.7.0-beta.28" />
+    <PackageReference Include="CodeDesignPlus.Net.RabbitMQ" Version="0.7.0-beta.28" />
+    <PackageReference Include="CodeDesignPlus.Net.Redis.Cache" Version="0.7.0-beta.28" />
 
     <PackageReference Include="AspNetCore.HealthChecks.MongoDb" Version="9.0.0" />
     <PackageReference Include="AspNetCore.HealthChecks.Rabbitmq" Version="9.0.0" />

--- a/src/entrypoints/CodeDesignPlus.Net.Microservice.gRpc/CodeDesignPlus.Net.Microservice.gRpc.csproj
+++ b/src/entrypoints/CodeDesignPlus.Net.Microservice.gRpc/CodeDesignPlus.Net.Microservice.gRpc.csproj
@@ -9,8 +9,8 @@
     <Protobuf Include="Protos\orders.proto" GrpcServices="Server" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="CodeDesignPlus.Net.Microservice.Commons" Version="0.7.0-beta.16" />
-    <PackageReference Include="CodeDesignPlus.Net.Vault" Version="0.7.0-beta.16" />
+    <PackageReference Include="CodeDesignPlus.Net.Microservice.Commons" Version="0.7.0-beta.28" />
+    <PackageReference Include="CodeDesignPlus.Net.Vault" Version="0.7.0-beta.28" />
     <PackageReference Include="Grpc.AspNetCore" Version="2.70.0" />
     <PackageReference Include="Grpc.AspNetCore.Server.Reflection" Version="2.70.0" />
     <PackageReference Include="Grpc.Tools" Version="2.70.0">
@@ -26,12 +26,12 @@
   <ItemGroup>
     <ProjectReference Include="..\..\domain\CodeDesignPlus.Net.Microservice.Infrastructure\CodeDesignPlus.Net.Microservice.Infrastructure.csproj" />
     <PackageReference Include="NodaTime.Serialization.Protobuf" Version="2.0.2" />
-    <PackageReference Include="CodeDesignPlus.Net.Redis" Version="0.7.0-beta.16" />
-    <PackageReference Include="CodeDesignPlus.Net.RabbitMQ" Version="0.7.0-beta.16" />
-    <PackageReference Include="CodeDesignPlus.Net.Logger" Version="0.7.0-beta.16" />
-    <PackageReference Include="CodeDesignPlus.Net.Observability" Version="0.7.0-beta.16" />
-    <PackageReference Include="CodeDesignPlus.Net.Security" Version="0.7.0-beta.16" />
-    <PackageReference Include="CodeDesignPlus.Net.Exceptions" Version="0.7.0-beta.16" />
-    <PackageReference Include="CodeDesignPlus.Net.Redis.Cache" Version="0.7.0-beta.16" />
+    <PackageReference Include="CodeDesignPlus.Net.Redis" Version="0.7.0-beta.28" />
+    <PackageReference Include="CodeDesignPlus.Net.RabbitMQ" Version="0.7.0-beta.28" />
+    <PackageReference Include="CodeDesignPlus.Net.Logger" Version="0.7.0-beta.28" />
+    <PackageReference Include="CodeDesignPlus.Net.Observability" Version="0.7.0-beta.28" />
+    <PackageReference Include="CodeDesignPlus.Net.Security" Version="0.7.0-beta.28" />
+    <PackageReference Include="CodeDesignPlus.Net.Exceptions" Version="0.7.0-beta.28" />
+    <PackageReference Include="CodeDesignPlus.Net.Redis.Cache" Version="0.7.0-beta.28" />
   </ItemGroup>
 </Project>

--- a/tests/integration/CodeDesignPlus.Net.Microservice.AsyncWorker.Test/CodeDesignPlus.Net.Microservice.AsyncWorker.Test.csproj
+++ b/tests/integration/CodeDesignPlus.Net.Microservice.AsyncWorker.Test/CodeDesignPlus.Net.Microservice.AsyncWorker.Test.csproj
@@ -11,7 +11,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="CodeDesignPlus.Net.xUnit.Microservice" Version="0.7.0-beta.16" />
+    <PackageReference Include="CodeDesignPlus.Net.xUnit.Microservice" Version="0.7.0-beta.28" />
     <PackageReference Include="Ductus.FluentDocker.XUnit" Version="2.10.59" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />

--- a/tests/integration/CodeDesignPlus.Net.Microservice.Rest.Test/CodeDesignPlus.Net.Microservice.Rest.Test.csproj
+++ b/tests/integration/CodeDesignPlus.Net.Microservice.Rest.Test/CodeDesignPlus.Net.Microservice.Rest.Test.csproj
@@ -12,7 +12,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.3.0" />
-    <PackageReference Include="CodeDesignPlus.Net.xUnit.Microservice" Version="0.7.0-beta.16" />
+    <PackageReference Include="CodeDesignPlus.Net.xUnit.Microservice" Version="0.7.0-beta.28" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.4" />
     <PackageReference Include="Ductus.FluentDocker.XUnit" Version="2.10.59" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />

--- a/tests/integration/CodeDesignPlus.Net.Microservice.gRpc.Test/CodeDesignPlus.Net.Microservice.gRpc.Test.csproj
+++ b/tests/integration/CodeDesignPlus.Net.Microservice.gRpc.Test/CodeDesignPlus.Net.Microservice.gRpc.Test.csproj
@@ -19,7 +19,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NodaTime.Serialization.Protobuf" Version="2.0.2" />
-    <PackageReference Include="CodeDesignPlus.Net.xUnit.Microservice" Version="0.7.0-beta.16" />
+    <PackageReference Include="CodeDesignPlus.Net.xUnit.Microservice" Version="0.7.0-beta.28" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="9.0.4" />

--- a/tests/unit/CodeDesignPlus.Net.Microservice.AsyncWorker.Test/CodeDesignPlus.Net.Microservice.AsyncWorker.Test.csproj
+++ b/tests/unit/CodeDesignPlus.Net.Microservice.AsyncWorker.Test/CodeDesignPlus.Net.Microservice.AsyncWorker.Test.csproj
@@ -17,7 +17,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="CodeDesignPlus.Net.xUnit.Microservice" Version="0.7.0-beta.16" />
+    <PackageReference Include="CodeDesignPlus.Net.xUnit.Microservice" Version="0.7.0-beta.28" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />

--- a/tests/unit/CodeDesignPlus.Net.Microservice.Default.Test/CodeDesignPlus.Net.Microservice.Default.Test.csproj
+++ b/tests/unit/CodeDesignPlus.Net.Microservice.Default.Test/CodeDesignPlus.Net.Microservice.Default.Test.csproj
@@ -6,7 +6,7 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CodeDesignPlus.Net.Serializers" Version="0.7.0-beta.16" />
+    <PackageReference Include="CodeDesignPlus.Net.Serializers" Version="0.7.0-beta.28" />
     <PackageReference Include="coverlet.msbuild" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
@@ -24,7 +24,7 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="CodeDesignPlus.Net.xUnit.Microservice" Version="0.7.0-beta.16" />
+    <PackageReference Include="CodeDesignPlus.Net.xUnit.Microservice" Version="0.7.0-beta.28" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\domain\CodeDesignPlus.Net.Microservice.Infrastructure\CodeDesignPlus.Net.Microservice.Infrastructure.csproj" />

--- a/tests/unit/CodeDesignPlus.Net.Microservice.Rest.Test/CodeDesignPlus.Net.Microservice.Rest.Test.csproj
+++ b/tests/unit/CodeDesignPlus.Net.Microservice.Rest.Test/CodeDesignPlus.Net.Microservice.Rest.Test.csproj
@@ -22,7 +22,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="CodeDesignPlus.Net.xUnit.Microservice" Version="0.7.0-beta.16" />
+    <PackageReference Include="CodeDesignPlus.Net.xUnit.Microservice" Version="0.7.0-beta.28" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />

--- a/tests/unit/CodeDesignPlus.Net.Microservice.gRpc.Test/CodeDesignPlus.Net.Microservice.gRpc.Test.csproj
+++ b/tests/unit/CodeDesignPlus.Net.Microservice.gRpc.Test/CodeDesignPlus.Net.Microservice.gRpc.Test.csproj
@@ -17,7 +17,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="CodeDesignPlus.Net.xUnit.Microservice" Version="0.7.0-beta.16" />
+    <PackageReference Include="CodeDesignPlus.Net.xUnit.Microservice" Version="0.7.0-beta.28" />
     <PackageReference Include="Grpc.Core.Testing" Version="2.46.6" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="Moq" Version="4.20.72" />


### PR DESCRIPTION
This pull request updates multiple project dependencies across the solution to use version `0.7.0-beta.28` of the `CodeDesignPlus.Net` packages, replacing the previously used version `0.7.0-beta.16`. The changes ensure consistency in dependency versions across all projects, including application, entrypoint, and test projects.

### Dependency Updates

#### Application Projects:
* Updated `CodeDesignPlus.Net.Generator`, `CodeDesignPlus.Net.Redis.Abstractions`, `CodeDesignPlus.Net.PubSub.Abstractions`, and `CodeDesignPlus.Net.Cache.Abstractions` to version `0.7.0-beta.28` in `CodeDesignPlus.Net.Microservice.Application.csproj`.
* Updated `CodeDesignPlus.Net.Exceptions` and `CodeDesignPlus.Net.Mongo` to version `0.7.0-beta.28` in `CodeDesignPlus.Net.Microservice.Domain.csproj`.

#### Entrypoint Projects:
* Updated multiple dependencies, including `CodeDesignPlus.Net.Microservice.Commons`, `CodeDesignPlus.Net.Vault`, `CodeDesignPlus.Net.Redis`, `CodeDesignPlus.Net.RabbitMQ`, `CodeDesignPlus.Net.Logger`, `CodeDesignPlus.Net.Observability`, `CodeDesignPlus.Net.Security`, and `CodeDesignPlus.Net.Redis.Cache` to version `0.7.0-beta.28` in:
  - `CodeDesignPlus.Net.Microservice.AsyncWorker.csproj`.
  - `CodeDesignPlus.Net.Microservice.Rest.csproj`.
  - `CodeDesignPlus.Net.Microservice.gRpc.csproj`. [[1]](diffhunk://#diff-10e97d915ad890abba7b13a046d4c3d952cdf15047b8be0cdf6dc32f33c2c105L12-R13) [[2]](diffhunk://#diff-10e97d915ad890abba7b13a046d4c3d952cdf15047b8be0cdf6dc32f33c2c105L29-R35)

#### Test Projects:
* Updated `CodeDesignPlus.Net.xUnit.Microservice` to version `0.7.0-beta.28` in integration and unit test projects:
  - Integration tests: `CodeDesignPlus.Net.Microservice.AsyncWorker.Test.csproj` [[1]](diffhunk://#diff-d4332bb0813c02a1de1e63055dbfe7cde1c2977c555799f8e738bad40b76bc1bL14-R14) `CodeDesignPlus.Net.Microservice.Rest.Test.csproj` [[2]](diffhunk://#diff-3f0ca21237fa605a56391f1c3329a4e9d454e6f53dcfb4749426a62a6064c1d9L15-R15) `CodeDesignPlus.Net.Microservice.gRpc.Test.csproj` [[3]](diffhunk://#diff-f2f8d7cfca2836e1b330e70c76ef962461f7dcf6733ee9ebf64c32746db8cfadL22-R22).
  - Unit tests: `CodeDesignPlus.Net.Microservice.AsyncWorker.Test.csproj` [[1]](diffhunk://#diff-853b65809280b069245819f3e90e3d773529c69acd9fceae6853a5e1e594f9b2L20-R20) `CodeDesignPlus.Net.Microservice.Default.Test.csproj` [[2]](diffhunk://#diff-faa31fd8c6bf56f2e815276c93cc635bdb130ffcfe6ae914986ae70dc4d8232aL9-R9) [[3]](diffhunk://#diff-faa31fd8c6bf56f2e815276c93cc635bdb130ffcfe6ae914986ae70dc4d8232aL27-R27) `CodeDesignPlus.Net.Microservice.Rest.Test.csproj` [[4]](diffhunk://#diff-26202e82245e4c87255c7b172b273fdcb8ee3f17c01a02a924b4c6d81af00e03L25-R25) `CodeDesignPlus.Net.Microservice.gRpc.Test.csproj` [[5]](diffhunk://#diff-b9d1618ad36510e6adc485de1db26b5992e47f80b528d7b820e998c762534f2cL20-R20).